### PR TITLE
HDFS-13538. HDFS DiskChecker should handle disk full situation

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/DiskChecker.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/DiskChecker.java
@@ -267,7 +267,10 @@ public class DiskChecker {
           ioe = e;
         }
       }
-      throw ioe;  // Just rethrow the last exception to signal failure.
+      // Throw the exception only if it's not about disk being full.
+      if (!ioe.getMessage().contains("No space left")) {
+        throw ioe;  // Just rethrow the last exception to signal failure.
+      }
     } catch(IOException e) {
       throw new DiskErrorException("Error checking directory " + dir, e);
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestDiskCheckerWithDiskIo.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/util/TestDiskCheckerWithDiskIo.java
@@ -33,6 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 
 /**
@@ -48,7 +49,7 @@ public final class TestDiskCheckerWithDiskIo {
   @Test
   public final void testDiskIoIgnoresTransientCreateErrors() throws Throwable {
     DiskChecker.replaceFileOutputStreamProvider(new TestFileIoProvider(
-        DiskChecker.DISK_IO_MAX_ITERATIONS - 1, 0));
+        DiskChecker.DISK_IO_MAX_ITERATIONS - 1, 0, false));
     checkDirs(true);
   }
 
@@ -59,7 +60,7 @@ public final class TestDiskCheckerWithDiskIo {
   public final void testDiskIoDetectsCreateErrors() throws Throwable {
     assertThrows(DiskErrorException.class, () -> {
       DiskChecker.replaceFileOutputStreamProvider(new TestFileIoProvider(
-          DiskChecker.DISK_IO_MAX_ITERATIONS, 0));
+          DiskChecker.DISK_IO_MAX_ITERATIONS, 0, false));
       checkDirs(false);
     });
   }
@@ -70,7 +71,7 @@ public final class TestDiskCheckerWithDiskIo {
   @Test
   public final void testDiskIoIgnoresTransientWriteErrors() throws Throwable {
     DiskChecker.replaceFileOutputStreamProvider(new TestFileIoProvider(
-        0, DiskChecker.DISK_IO_MAX_ITERATIONS - 1));
+        0, DiskChecker.DISK_IO_MAX_ITERATIONS - 1, false));
     checkDirs(true);
   }
 
@@ -81,7 +82,7 @@ public final class TestDiskCheckerWithDiskIo {
   public final void testDiskIoDetectsWriteErrors() throws Throwable {
     assertThrows(DiskErrorException.class, ()->{
       DiskChecker.replaceFileOutputStreamProvider(new TestFileIoProvider(
-          0, DiskChecker.DISK_IO_MAX_ITERATIONS));
+          0, DiskChecker.DISK_IO_MAX_ITERATIONS, false));
       checkDirs(false);
     });
   }
@@ -105,6 +106,18 @@ public final class TestDiskCheckerWithDiskIo {
   }
 
   /**
+   * Verify DiskChecker doesn't fail on ENOSPC errors.
+   */
+  @Test
+  public void testDiskIoDetectsENOSPCWriteErrors() {
+    assertDoesNotThrow(()->{
+      DiskChecker.replaceFileOutputStreamProvider(new TestFileIoProvider(
+          0, DiskChecker.DISK_IO_MAX_ITERATIONS, true));
+      checkDirs(true);
+    });
+  }
+
+  /**
    * A dummy {@link DiskChecker#FileIoProvider} that can throw a programmable
    * number of times.
    */
@@ -114,11 +127,13 @@ public final class TestDiskCheckerWithDiskIo {
 
     private final int numTimesToThrowOnCreate;
     private final int numTimesToThrowOnWrite;
+    private final boolean throwENOSPCError;
 
     public TestFileIoProvider(
-        int numTimesToThrowOnCreate, int numTimesToThrowOnWrite) {
+        int numTimesToThrowOnCreate, int numTimesToThrowOnWrite, boolean throwENOSPCError) {
       this.numTimesToThrowOnCreate = numTimesToThrowOnCreate;
       this.numTimesToThrowOnWrite = numTimesToThrowOnWrite;
+      this.throwENOSPCError = throwENOSPCError;
     }
 
     /**
@@ -139,7 +154,11 @@ public final class TestDiskCheckerWithDiskIo {
     @Override
     public void write(FileOutputStream fos, byte[] data) throws IOException {
       if (numWriteCalls.getAndIncrement() < numTimesToThrowOnWrite) {
-        throw new IOException("Dummy exception for testing");
+        if (!throwENOSPCError) {
+          throw new IOException("Dummy exception for testing");
+        } else {
+          throw new IOException("No space left on device");
+        }
       }
       fos.write(data);
     }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSConfigKeys.java
@@ -190,6 +190,10 @@ public class DFSConfigKeys extends CommonConfigurationKeys {
   public static final long DFS_DN_CACHED_DFSUSED_CHECK_INTERVAL_DEFAULT_MS =
       600000;
 
+  public static final String DFS_DATANODE_CHECK_DIR_WITH_DISKIO =
+      "dfs.datanode.check.dir.with.diskio";
+  public static final boolean DFS_DATANODE_CHECK_DIR_WITH_DISKIO_DEFAULT = false;
+
   public static final String  DFS_NAMENODE_PATH_BASED_CACHE_BLOCK_MAP_ALLOCATION_PERCENT =
       "dfs.namenode.path.based.cache.block.map.allocation.percent";
   public static final float    DFS_NAMENODE_PATH_BASED_CACHE_BLOCK_MAP_ALLOCATION_PERCENT_DEFAULT = 0.25f;

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/BlockPoolSlice.java
@@ -120,6 +120,7 @@ public class BlockPoolSlice {
   private final long cachedDfsUsedCheckTime;
   private final Timer timer;
   private final int maxDataLength;
+  private final boolean checkDirWithDiskIo;
   private final FileIoProvider fileIoProvider;
   private final Configuration config;
   private final File bpDir;
@@ -178,6 +179,10 @@ public class BlockPoolSlice {
     this.maxDataLength = conf.getInt(
         CommonConfigurationKeys.IPC_MAXIMUM_DATA_LENGTH,
         CommonConfigurationKeys.IPC_MAXIMUM_DATA_LENGTH_DEFAULT);
+
+    this.checkDirWithDiskIo = conf.getBoolean(
+        DFSConfigKeys.DFS_DATANODE_CHECK_DIR_WITH_DISKIO,
+        DFSConfigKeys.DFS_DATANODE_CHECK_DIR_WITH_DISKIO_DEFAULT);
 
     this.timer = timer;
 
@@ -484,9 +489,15 @@ public class BlockPoolSlice {
   }
 
   void checkDirs() throws DiskErrorException {
-    DiskChecker.checkDir(finalizedDir);
-    DiskChecker.checkDir(tmpDir);
-    DiskChecker.checkDir(rbwDir);
+    if (checkDirWithDiskIo) {
+      DiskChecker.checkDirWithDiskIo(finalizedDir);
+      DiskChecker.checkDirWithDiskIo(tmpDir);
+      DiskChecker.checkDirWithDiskIo(rbwDir);
+    } else {
+      DiskChecker.checkDir(finalizedDir);
+      DiskChecker.checkDir(tmpDir);
+      DiskChecker.checkDir(rbwDir);
+    }
   }
 
 


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
    1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
    2. Make sure your PR title starts with JIRA issue id, e.g., 'HADOOP-17799. Your PR title ...'.
-->

### Description of PR

DiskChecker was enhanced to do checking with some i/o in [HADOOP-13738](https://issues.apache.org/jira/browse/HADOOP-13738). But this was rolled back partially because of fsync issue seen in [HADOOP-15450](https://issues.apache.org/jira/browse/HADOOP-15450) and the problem of disk full being flagged as a check failure ([HDFS-13538](https://issues.apache.org/jira/browse/HDFS-13538)).

This PR tries to address [HDFS-13538](https://issues.apache.org/jira/browse/HDFS-13538) and enable i/o based disk checking ONLY for HDFS with a flag that can be turned on in dfs configs.


### How was this patch tested?


### For code changes:

- [ ] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

